### PR TITLE
Increase multiplier for mainnet deploys

### DIFF
--- a/src/contractor/deployer.py
+++ b/src/contractor/deployer.py
@@ -9,7 +9,7 @@ from hexbytes import HexBytes
 
 logger = logging.getLogger(__name__)
 
-GAS_MULTIPLIER = 1.2
+GAS_MULTIPLIER = 3
 
 
 # For polyswarmd compatibility


### PR DESCRIPTION
estimate gas is off on mainnet. Increasing multiplier to increase probability of getting high enough gas limit. 