### PR TITLE
Actually track the current nonce internally and compare w/ provider

### DIFF
--- a/src/contractor/network.py
+++ b/src/contractor/network.py
@@ -70,17 +70,14 @@ class Network(object):
         self.nonce = self.__get_nonce()
 
     def __get_nonce(self):
-        last_nonce = -1
-        while True:
-            # Also include transactions in txpool
-            nonce = self.w3.eth.getTransactionCount(self.account, 'pending')
+        # the following assumes __get_nonce is only called when a tx is actually sent
+        
+        reported_nonce = self.w3.eth.getTransactionCount(self.account, 'pending')
 
-            if nonce == last_nonce:
-                logger.info('Settled on transaction count %s', nonce)
-                break
-
-            last_nonce = nonce
-            time.sleep(2)
+        if reported_nonce > self.nonce+1:
+            nonce = reported_nonce
+        else:
+            nonce = self.nonce+1
 
         return nonce
 


### PR DESCRIPTION
`__get_nonce` as written will definitely fail intermittently on mainnet. Instead, simply track the nonces used internally and comapre against pending, and use the biggest of the two. This also removes the minimum 2 second delay between each tx.