### PR TITLE
Add deprecate function BountyRegistry and let Arbiters withdraw stake when Bounty is deprecated

### DIFF
--- a/contracts/BountyRegistry.sol
+++ b/contracts/BountyRegistry.sol
@@ -247,19 +247,19 @@ contract BountyRegistry is Pausable, Ownable {
         emit WindowsUpdated(ASSERTION_REVEAL_WINDOW, arbiterVoteWindow);
     }
 
-    /**
-     * Deprecate this contract
-     * The contract disables new bounties, but allows other parts to function
-     */
-    function deprecate() external onlyOwner {
-        deprecatedBlock = block.number;
-        emit Deprecated(address(this));
-    }
-
     /** Function only callable when not deprecated */
     modifier whenNotDeprecated() {
         require(deprecatedBlock == 0, "Contract is deprecated");
         _;
+    }
+
+    /**
+     * Deprecate this contract
+     * The contract disables new bounties, but allows other parts to function
+     */
+    function deprecate() external onlyOwner whenNotDeprecated {
+        deprecatedBlock = block.number;
+        emit Deprecated(address(this));
     }
 
     /**

--- a/contracts/BountyRegistry.sol
+++ b/contracts/BountyRegistry.sol
@@ -251,7 +251,7 @@ contract BountyRegistry is Pausable, Ownable {
      * Deprecate this contract
      * The contract disables new bounties, but allows other parts to function
      */
-    function deprecate() externam onlyOwner {
+    function deprecate() external onlyOwner {
         deprecatedBlock = block.number;
         emit Deprecated(deprecatedBlock);
     }

--- a/contracts/BountyRegistry.sol
+++ b/contracts/BountyRegistry.sol
@@ -143,7 +143,7 @@ contract BountyRegistry is Pausable, Ownable {
     );
 
     event Deprecated(
-        uint256 blockNumber
+        address indexed bountyRegistry
     );
 
     uint256 public deprecatedBlock;
@@ -253,7 +253,7 @@ contract BountyRegistry is Pausable, Ownable {
      */
     function deprecate() external onlyOwner {
         deprecatedBlock = block.number;
-        emit Deprecated(deprecatedBlock);
+        emit Deprecated(address(this));
     }
 
     /** Function only callable when not deprecated */

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,37 @@ def arbiter_staking(artifacts, eth_tester, web3):
                                        ('network', 'deployer', 'NectarToken', 'BountyRegistry', 'ArbiterStaking'))
     return ArbiterStakingFixture(network, deployer, nectar_token, bounty_registry, arbiter_staking)
 
+@pytest.fixture
+def arbiter_long_staking(artifacts, eth_tester, web3):
+    chain = Chain.HOMECHAIN
+    arbiter = TestAccount(eth_tester)
+    fee_manager = TestAccount(eth_tester)
+    window_manager = TestAccount(eth_tester)
+
+    nectar_token = NectarToken([], [arbiter])
+    bounty_registry = BountyRegistry(nectar_token, 10000000 * 10 ** 18, 100, [], [], [arbiter], fee_manager,
+                                     window_manager)
+    arbiter_staking = ArbiterStaking(nectar_token, bounty_registry, 100000, arbiter)
+
+    config = {
+        'NectarToken': nectar_token.config(chain),
+        'BountyRegistry': bounty_registry.config(chain),
+        'ArbiterStaking': arbiter_staking.config(chain),
+    }
+
+    network, deployer = deploy(config, chain, artifacts, eth_tester, web3)
+
+    nectar_token.bind(deployer.contracts['NectarToken'])
+    nectar_token.owner = network.address
+    bounty_registry.bind(deployer.contracts['BountyRegistry'])
+    bounty_registry.owner = network.address
+    arbiter_staking.bind(deployer.contracts['ArbiterStaking'])
+    arbiter_staking.owner = network.address
+
+    ArbiterStakingFixture = namedtuple('ArbiterStakingFixture',
+                                       ('network', 'deployer', 'NectarToken', 'BountyRegistry', 'ArbiterStaking'))
+    return ArbiterStakingFixture(network, deployer, nectar_token, bounty_registry, arbiter_staking)
+
 
 @pytest.fixture
 def erc20_relay(artifacts, eth_tester, web3):

--- a/tests/test_BountyRegistry.py
+++ b/tests/test_BountyRegistry.py
@@ -224,6 +224,20 @@ def test_post_bounty(bounty_registry):
     assert BountyRegistry.functions.bountiesByGuid(guid).call()[0] == guid
 
 
+def test_post_bounty_deprecated(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+
+    ambassador = BountyRegistry.ambassadors[0]
+    guid = random_guid()
+    uri = random_artifact_uri()
+    amount = 10 * 10 ** 18
+
+    BountyRegistry.functions.deprecate().transact({"from": BountyRegistry.owner})
+
+    with pytest.raises(TransactionFailed):
+        post_bounty(bounty_registry, ambassador.address, guid=guid, artifact_type=0, uri=uri, amount=amount)
+
+
 def test_reject_duplicate_guids(bounty_registry):
     BountyRegistry = bounty_registry.BountyRegistry
 

--- a/tests/test_BountyRegistry.py
+++ b/tests/test_BountyRegistry.py
@@ -199,6 +199,17 @@ def test_should_allow_owner_to_perform_window_management_if_no_manager_set(bount
     BountyRegistry.functions.setArbiterVoteWindow(3).transact({'from': window_manager.address})
 
 
+def test_emit_event_deprecate(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    txhash = BountyRegistry.functions.deprecate().transact({"from": BountyRegistry.owner})
+
+    deprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+
+    assert deprecate[0].args['bountyRegistry'] == BountyRegistry.address
+
+
 def test_post_bounty(bounty_registry):
     NectarToken = bounty_registry.NectarToken
     BountyRegistry = bounty_registry.BountyRegistry


### PR DESCRIPTION
Let arbiters get their stake when BountyRegistry is deprecated, and enough blocks have passed to settle all bounties that came in before the contract was deprecated. 