### PR TITLE
Enabling branch-based multi-project merge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ stages:
 
 variables:
   DOCKER_HOST: tcp://localhost:2375/
+  BASE_IMAGE_NAME: contractor
 
 ###############################################################
 # Build Stage (jobs inside a stage run in parallel)
@@ -67,13 +68,13 @@ release-latest-linux:
     - master
   script:
     # Gets the current image that was built in the CI for this commit
-    - docker pull $REPO_URL/contractor:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA}
+    - docker pull $REPO_URL/$BASE_IMAGE_NAME:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA}
     # Creates new tags for this image, one that should go to AWS and another to DockerHub with the tag "latest"
-    - docker tag $REPO_URL/contractor:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} $REPO_URL/contractor:latest
-    - docker tag $REPO_URL/contractor:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} polyswarm/contractor:latest
+    - docker tag $REPO_URL/$BASE_IMAGE_NAME:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} $REPO_URL/$BASE_IMAGE_NAME:latest
+    - docker tag $REPO_URL/$BASE_IMAGE_NAME:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} polyswarm/$BASE_IMAGE_NAME:latest
     # Pushes to AWS
-    - docker push $REPO_URL/contractor:latest
+    - docker push $REPO_URL/$BASE_IMAGE_NAME:latest
     # Pushes to Docker Hub
     - docker logout
     - docker login -u "$CI_CUSTOM_DOCKER_HUB_USERNAME" -p "$CI_CUSTOM_DOCKER_HUB_PASSWORD"
-    - docker push polyswarm/contractor:latest
+    - docker push polyswarm/$BASE_IMAGE_NAME:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,10 +68,10 @@ release-latest-linux:
     - master
   script:
     # Gets the current image that was built in the CI for this commit
-    - docker pull $REPO_URL/$BASE_IMAGE_NAME:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA}
+    - docker pull $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
     # Creates new tags for this image, one that should go to AWS and another to DockerHub with the tag "latest"
-    - docker tag $REPO_URL/$BASE_IMAGE_NAME:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} $REPO_URL/$BASE_IMAGE_NAME:latest
-    - docker tag $REPO_URL/$BASE_IMAGE_NAME:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} polyswarm/$BASE_IMAGE_NAME:latest
+    - docker tag $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA $REPO_URL/$BASE_IMAGE_NAME:latest
+    - docker tag $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA polyswarm/$BASE_IMAGE_NAME:latest
     # Pushes to AWS
     - docker push $REPO_URL/$BASE_IMAGE_NAME:latest
     # Pushes to Docker Hub

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,32 +16,25 @@ variables:
 # Build Stage (jobs inside a stage run in parallel)
 ###############################################################
 
-# triggers itself in a new pipeline with the MANUAL_IMAGE_TAG=manual-tag
-self-trigger-with-manual-tag:
-  stage: build
-  tags:
-    - kube
-  script:
-    - >-
-      curl
-      --request POST
-      --form "token=$CI_JOB_TOKEN"
-      --form "variables[MANUAL_IMAGE_TAG]=manual-tag"
-      --form ref=$CI_COMMIT_REF_NAME
-      "https://gitlab.polyswarm.io/api/v4/projects/$CI_PROJECT_ID/trigger/pipeline"
-  when: manual
-
 build-linux:
   stage: build
-  variables:
-    GIT_SUBMODULE_STRATEGY: recursive
   tags:
     - kube
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
   script:
-    - docker pull $REPO_URL/contractor:latest || true
-    - docker build -t $REPO_URL/contractor:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA} -f docker/Dockerfile --cache-from=$REPO_URL/contractor:latest .
-    - docker push $REPO_URL/contractor:${MANUAL_IMAGE_TAG:-$CI_COMMIT_SHA}
-
+     # try to download a cache image
+     - docker pull $REPO_URL/$BASE_IMAGE_NAME:latest || true
+     # explicitly pull the latest version of the dependant image
+     - docker pull python:3.6-slim-stretch
+     - docker build
+       -f docker/Dockerfile
+       -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+       -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
+       --cache-from=$REPO_URL/$BASE_IMAGE_NAME:latest
+       .
+     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
 
 ###############################################################
 # Test Stage


### PR DESCRIPTION
This tags the image with the branch name and uses e2e from the branch if available as well. e2e checks for alike branches when pulling images.