### PR TITLE
Fix ContextualVersionConflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pytest-cov==2.6.0
 pytest-xdist==1.26.1
 python-consul==1.1.0
 PyYaml==5.1
-py-evm==0.3.0a1
 rlp==1.1.0
 slither-analyzer==0.5.1
 SQLAlchemy==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama==0.4.1
 coverage==4.5.1
 ethereum==2.3.2
 eth-account==0.3.0
-eth-tester[py-evm]==0.1.0b33
+eth-tester[py-evm]==0.1.0b39
 hexbytes==0.1.0
 ipython==7.3.0
 requests==2.21.0
@@ -14,11 +14,12 @@ pytest-cov==2.6.0
 pytest-xdist==1.26.1
 python-consul==1.1.0
 PyYaml==5.1
+py-evm==0.3.0a1
 rlp==1.1.0
 slither-analyzer==0.5.1
 SQLAlchemy==1.3.0
 toposort==1.5
 tabulate==0.8.2
-trezor[ethereum,hidapi]==0.11.1
-web3==4.8.1
+trezor[ethereum,hidapi]==0.11.4
+web3==4.9.2
 git+https://github.com/polyswarm/py-solc.git@feature/0-5-3#egg=py-solc

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
         "toposort==1.5",
         "tabulate==0.8.2",
         "trezor[ethereum,hidapi]==0.11.4",
-        "web3==4.9.2"
+        "web3==4.9.2",
+        "py-solc @ git+http://github.com/polyswarm/py-solc.git@feature/0-5-3",
     ],
     include_package_data=True,
     packages=find_packages('src'),

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 from setuptools import find_packages, setup
 
 
-def parse_requirements():
-    with open('requirements.txt', 'r') as f:
-        return [r for r in f.read().splitlines() if not r.startswith('git')]
-
-
 setup(
     name='contractor',
     version='0.2.0',
@@ -15,7 +10,22 @@ setup(
     url='https://github.com/polyswarm/contracts',
     license='MIT',
     python_requires='>=3.5,<4',
-    install_requires=parse_requirements(),
+    install_requires=[
+        "click==7.0",
+        "ethereum==2.3.2",
+        "eth-account==0.3.0",
+        "hexbytes==0.1.0",
+        "ipython==7.3.0",
+        "requests==2.21.0",
+        "psycopg2-binary==2.7.6.1",
+        "python-consul==1.1.0",
+        "PyYaml==5.1",
+        "SQLAlchemy==1.3.0",
+        "toposort==1.5",
+        "tabulate==0.8.2",
+        "trezor[ethereum,hidapi]==0.11.4",
+        "web3==4.9.2"
+    ],
     include_package_data=True,
     packages=find_packages('src'),
     package_dir={'': 'src'},


### PR DESCRIPTION
Fix the versions incompatibilities in our required projects. 
Switch from parse_requirements to a deliberate list of required projects, including polyswarm/py-solc with correct syntax. 

Fixes #63 