### PR TITLE
Fix ContextualVersionConflict with less duplication

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 WORKDIR /usr/src/app
 
-COPY requirements.txt ./
+COPY requirements*.txt ./
 
 RUN set -x && pip install --no-cache-dir -r requirements.txt -r requirements_test.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 WORKDIR /usr/src/app
 
-COPY requirements*.txt ./
+COPY requirements.txt requirements_test.txt ./
 
 RUN set -x && pip install --no-cache-dir -r requirements.txt -r requirements_test.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt ./
 
-RUN set -x && pip install --no-cache-dir -r requirements.txt
+RUN set -x && pip install --no-cache-dir -r requirements.txt -r requirements_test.txt
 
 COPY . .
 RUN set -x && pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,11 @@
 click==7.0
 colorama==0.4.1
-coverage==4.5.1
 ethereum==2.3.2
 eth-account==0.3.0
 hexbytes==0.1.0
 ipython==7.3.0
 requests==2.21.0
 psycopg2-binary==2.7.6.1
-pycodestyle==2.4.0
-pytest==4.0.0
-pytest-cov==2.6.0
-pytest-xdist==1.26.1
 python-consul==1.1.0
 PyYaml==5.1
 rlp==1.1.0
@@ -21,5 +16,3 @@ tabulate==0.8.2
 trezor[ethereum,hidapi]==0.11.4
 web3==4.8.3
 git+https://github.com/polyswarm/py-solc.git@feature/0-5-3#egg=py-solc
-
-eth-tester[py-evm]==0.1.0b33

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ colorama==0.4.1
 coverage==4.5.1
 ethereum==2.3.2
 eth-account==0.3.0
-eth-tester[py-evm]==0.1.0b33
 hexbytes==0.1.0
 ipython==7.3.0
 requests==2.21.0
@@ -19,6 +18,8 @@ slither-analyzer==0.5.1
 SQLAlchemy==1.3.0
 toposort==1.5
 tabulate==0.8.2
-trezor[ethereum,hidapi]==0.11.1
-web3==4.8.1
+trezor[ethereum,hidapi]==0.11.4
+web3==4.8.3
 git+https://github.com/polyswarm/py-solc.git@feature/0-5-3#egg=py-solc
+
+eth-tester[py-evm]==0.1.0b33

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,6 @@
+coverage==4.5.1
+eth-tester[py-evm]==0.1.0b33
+pycodestyle==2.4.0
+pytest==4.0.0
+pytest-cov==2.6.0
+pytest-xdist==1.26.1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,19 @@
 from setuptools import find_packages, setup
 
 
+test_dependencies = [
+        "coverage==4.5.1",
+        "eth-tester[py-evm]==0.1.0b33",
+        "pycodestyle==2.4.0",
+        "pytest==4.0.0",
+        "pytest-cov==2.6.0",
+        "pytest-xdist==1.26.1",
+    ]
+
+
 def parse_requirements():
     with open('requirements.txt', 'r') as f:
-        return [r for r in f.read().splitlines() if not r.startswith('git')]
+        return [r for r in f.read().splitlines() if not r.startswith('git') and r not in test_dependencies]
 
 
 setup(
@@ -15,7 +25,7 @@ setup(
     url='https://github.com/polyswarm/contracts',
     license='MIT',
     python_requires='>=3.5,<4',
-    install_requires=parse_requirements(),
+    install_requires=parse_requirements() + ["py-solc @ git+http://github.com/polyswarm/py-solc.git@feature/0-5-3"],
     include_package_data=True,
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,29 @@ from setuptools import find_packages, setup
 
 
 test_dependencies = [
-        "coverage==4.5.1",
-        "eth-tester[py-evm]==0.1.0b33",
-        "pycodestyle==2.4.0",
-        "pytest==4.0.0",
-        "pytest-cov==2.6.0",
-        "pytest-xdist==1.26.1",
+        'coverage==4.5.1',
+        'eth-tester[py-evm]==0.1.0b33',
+        'pycodestyle==2.4.0',
+        'pytest==4.0.0',
+        'pytest-cov==2.6.0',
+        'pytest-xdist==1.26.1',
     ]
 
 
 def parse_requirements():
+    result = []
     with open('requirements.txt', 'r') as f:
-        return [r for r in f.read().splitlines() if not r.startswith('git') and r not in test_dependencies]
+        for r in f.read().splitlines():
+            if r in test_dependencies:
+                continue
+            elif r.startswith('git'):
+                url, name = r.split('egg=')
+                result.append('{0} @ {1}'.format(name, url))
+                continue
+
+            result.append(r)
+
+    return result
 
 
 setup(
@@ -25,7 +36,7 @@ setup(
     url='https://github.com/polyswarm/contracts',
     license='MIT',
     python_requires='>=3.5,<4',
-    install_requires=parse_requirements() + ["py-solc @ git+http://github.com/polyswarm/py-solc.git@feature/0-5-3"],
+    install_requires=parse_requirements(),
     include_package_data=True,
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,11 @@ def parse_requirements():
     result = []
     with open('requirements.txt', 'r') as f:
         for r in f.read().splitlines():
-            if r in test_dependencies:
-                continue
-            elif r.startswith('git'):
+            if r in test_dependencies and r.startswith('git'):
                 url, name = r.split('egg=', 1)
                 result.append('{0} @ {1}'.format(name, url))
-                continue
-
-            result.append(r)
+            elif r in test_dependencies:
+                result.append(r)
 
     return result
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def parse_requirements():
             if r in test_dependencies:
                 continue
             elif r.startswith('git'):
-                url, name = r.split('egg=')
+                url, name = r.split('egg=', 1)
                 result.append('{0} @ {1}'.format(name, url))
                 continue
 

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,10 @@
 from setuptools import find_packages, setup
 
 
-test_dependencies = [
-        'coverage==4.5.1',
-        'eth-tester[py-evm]==0.1.0b33',
-        'pycodestyle==2.4.0',
-        'pytest==4.0.0',
-        'pytest-cov==2.6.0',
-        'pytest-xdist==1.26.1',
-    ]
-
-
 def parse_requirements():
-    result = []
     with open('requirements.txt', 'r') as f:
-        for r in f.read().splitlines():
-            if r in test_dependencies and r.startswith('git'):
-                url, name = r.split('egg=', 1)
-                result.append('{0} @ {1}'.format(name, url))
-            elif r in test_dependencies:
-                result.append(r)
-
-    return result
+        return [r if not r.startswith('git') else '{1} @ {0}'.format(*r.split('#egg=', 1))
+                for r in f.read().splitlines()]
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py36
 
 [testenv]
-deps = -rrequirements.txt -rrequirements_test.txt
+deps =
+    -rrequirements.txt
+    -rrequirements_test.txt
 commands =
     python -m contractor install-solc
     pytest -s --cov=contractor -n auto

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py36
 
 [testenv]
-deps = -rrequirements.txt
+deps = -rrequirements.txt -rrequirements_test.txt
 commands =
     python -m contractor install-solc
     pytest -s --cov=contractor -n auto


### PR DESCRIPTION
Does minimal updates to setup to stop installing test deps when running `pip install .`. 

Now handles git dependencies in `parse_requirements()`. 

Fixes #63 