### PR TITLE
Reversable & Upgradeable contracts

### DIFF
--- a/contracts/ArbiterStaking.sol
+++ b/contracts/ArbiterStaking.sol
@@ -12,7 +12,7 @@ contract ArbiterStaking is Pausable, Ownable {
     using SafeMath for uint256;
     using SafeERC20 for NectarToken;
 
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.2.1";
 
     uint256 public constant MINIMUM_STAKE = 10000000 * 10 ** 18;
     uint256 public constant MAXIMUM_STAKE = 100000000 * 10 ** 18;

--- a/contracts/ArbiterStaking.sol
+++ b/contracts/ArbiterStaking.sol
@@ -247,8 +247,9 @@ contract ArbiterStaking is Pausable, Ownable {
      * @return true if deprecated block is set and beyond max blocks for a
      */
     function isDeprecated() public view returns (bool) {
-        uint256 longest = registry.MAX_DURATION().add(registry.assertionRevealWindow()).add(registry.arbiterVoteWindow());
-        return registry.deprecatedBlock() > 0 && block.number >= registry.deprecatedBlock().add(longest);
+        uint256 longest_bounty = registry.MAX_DURATION().add(registry.assertionRevealWindow()).add(registry.arbiterVoteWindow());
+        // is registry deprecated  && is arbiter staking NOT being rolled over  && Have all the bounties finished
+        return registry.deprecatedBlock() > 0 && !registry.seamless() && block.number >= registry.deprecatedBlock().add(longest_bounty);
     }
 
     /**

--- a/contracts/ArbiterStaking.sol
+++ b/contracts/ArbiterStaking.sol
@@ -249,7 +249,7 @@ contract ArbiterStaking is Pausable, Ownable {
     function isDeprecated() public view returns (bool) {
         uint256 longest_bounty = registry.MAX_DURATION().add(registry.assertionRevealWindow()).add(registry.arbiterVoteWindow());
         // is registry deprecated  && is arbiter staking NOT being rolled over  && Have all the bounties finished
-        return registry.deprecatedBlock() > 0 && !registry.seamless() && block.number >= registry.deprecatedBlock().add(longest_bounty);
+        return registry.deprecatedBlock() > 0 && !registry.rollover() && block.number >= registry.deprecatedBlock().add(longest_bounty);
     }
 
     /**

--- a/contracts/ArbiterStaking.sol
+++ b/contracts/ArbiterStaking.sol
@@ -155,7 +155,7 @@ contract ArbiterStaking is Pausable, Ownable {
      */
     function withdrawableBalanceOf(address addr) public view returns (uint256) {
         uint256 ret = 0;
-        bool deprecated = isDeprecated();
+        bool deprecated = isDeprecateFinished();
 
         if (!deprecated && block.number < stakeDuration) {
             return ret;
@@ -180,7 +180,7 @@ contract ArbiterStaking is Pausable, Ownable {
     function withdraw(uint256 value) public whenNotPaused {
         require(deposits[msg.sender].length > 0, "Cannot withdraw without some deposits.");
         uint256 remaining = value;
-        bool deprecated = isDeprecated();
+        bool deprecated = isDeprecateFinished();
 
         uint256 latest_block = !deprecated ? block.number.sub(stakeDuration) : block.number;
         Deposit[] storage ds = deposits[msg.sender];
@@ -246,7 +246,7 @@ contract ArbiterStaking is Pausable, Ownable {
      *
      * @return true if deprecated block is set and beyond max blocks for a
      */
-    function isDeprecated() public view returns (bool) {
+    function isDeprecateFinished() public view returns (bool) {
         uint256 longest_bounty = registry.MAX_DURATION().add(registry.assertionRevealWindow()).add(registry.arbiterVoteWindow());
         // is registry deprecated  && is arbiter staking NOT being rolled over  && Have all the bounties finished
         return registry.deprecatedBlock() > 0 && !registry.rollover() && block.number >= registry.deprecatedBlock().add(longest_bounty);

--- a/contracts/BountyRegistry.sol
+++ b/contracts/BountyRegistry.sol
@@ -16,7 +16,7 @@ contract BountyRegistry is ArbiterRole, FeeManagerRole, WindowManagerRole, Depre
     using SafeMath for uint256;
     using SafeERC20 for NectarToken;
 
-    string public constant VERSION = "1.5.0";
+    string public constant VERSION = "1.6.0";
 
     enum ArtifactType {FILE, URL, _END}
 

--- a/contracts/ERC20Relay.sol
+++ b/contracts/ERC20Relay.sol
@@ -9,7 +9,7 @@ contract ERC20Relay is Ownable {
     using SafeMath for uint256;
     using SafeERC20 for ERC20;
 
-    string public constant VERSION = "1.2.1";
+    string public constant VERSION = "1.2.0";
 
     /* Managers */
     address public verifierManager;

--- a/contracts/ERC20Relay.sol
+++ b/contracts/ERC20Relay.sol
@@ -9,7 +9,7 @@ contract ERC20Relay is Ownable {
     using SafeMath for uint256;
     using SafeERC20 for ERC20;
 
-    string public constant VERSION = "1.2.0";
+    string public constant VERSION = "1.2.1";
 
     /* Managers */
     address public verifierManager;

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -16,6 +16,16 @@ fi
 echo "Compiling contracts"
 contractor compile -o consul
 
+if [[ -f "consul/sidechain.json" ]]; then
+    echo "Deactivating existing sidechain BountyRegistry"
+    contractor deactivate --chain side --network $SIDECHAIN --keyfile $SIDECHAIN_KEYFILE -a consul -o consul/sidechain.json BountyRegistry
+fi
+
+if [[ -f "consul/homechain.json" ]]; then
+    echo "Deactivating existing homechain BountyRegistry"
+    contractor deactivate --chain home --network $HOMECHAIN --keyfile $HOMECHAIN_KEYFILE -a consul -o consul/homechain.json BountyRegistry
+fi
+
 # Deploy to sidechain first, as it's cheaper (free) in the case of failure
 echo "Deploying to sidechain"
 contractor deploy --chain side --network $SIDECHAIN --keyfile $SIDECHAIN_KEYFILE -a consul -o consul/sidechain.json

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -18,12 +18,12 @@ contractor compile -o consul
 
 if [[ -f "consul/sidechain.json" ]]; then
     echo "Deactivating existing sidechain BountyRegistry"
-    contractor deactivate --chain side --network $SIDECHAIN --keyfile $SIDECHAIN_KEYFILE -a consul -o consul/sidechain.json BountyRegistry
+    contractor deactivate contract --chain side --network $SIDECHAIN --keyfile $SIDECHAIN_KEYFILE -a consul -i consul/sidechain.json BountyRegistry
 fi
 
 if [[ -f "consul/homechain.json" ]]; then
     echo "Deactivating existing homechain BountyRegistry"
-    contractor deactivate --chain home --network $HOMECHAIN --keyfile $HOMECHAIN_KEYFILE -a consul -o consul/homechain.json BountyRegistry
+    contractor deactivate contract --chain home --network $HOMECHAIN --keyfile $HOMECHAIN_KEYFILE -a consul -i consul/homechain.json BountyRegistry
 fi
 
 # Deploy to sidechain first, as it's cheaper (free) in the case of failure

--- a/examples/example_config.yml
+++ b/examples/example_config.yml
@@ -34,6 +34,7 @@ contracts:
       - "0x3978005e1868a74a59fbdaead2b4a3dffb7261fd"
       - "0xc7ef8e97743bf867be0da864c7e2ae67428a507b"
   ArbiterStaking:
+    stake_duration: 100
   BountyRegistry:
     rollover: yes
     arbiters:

--- a/examples/example_config.yml
+++ b/examples/example_config.yml
@@ -33,7 +33,9 @@ contracts:
       - "0x7a5a8d58c637fc9586034c9d15fcdbe75453af46"
       - "0x3978005e1868a74a59fbdaead2b4a3dffb7261fd"
       - "0xc7ef8e97743bf867be0da864c7e2ae67428a507b"
+  ArbiterStaking:
   BountyRegistry:
+    rollover: yes
     arbiters:
       - "0x29f9c138f445dde9330361b4dcf3db635fab2672"
       - "0x69d568837a75cd385ce6cafa176d878a1d3dc18f"

--- a/external/polyswarm/lifecycle/Deprecatable.sol
+++ b/external/polyswarm/lifecycle/Deprecatable.sol
@@ -49,7 +49,7 @@ contract Deprecatable is DeprecatorRole {
      * The re-enables anything disabled by deprecation
      */
     function undeprecate() external onlyDeprecator whenDeprecated {
-        deprecatedBlock = block.number;
+        deprecatedBlock = 0;
         rollover = false;
         emit Undeprecated();
     }

--- a/external/polyswarm/lifecycle/Deprecatable.sol
+++ b/external/polyswarm/lifecycle/Deprecatable.sol
@@ -10,16 +10,16 @@ import "../access/roles/DeprecatorRole.sol";
  */
 contract Deprecatable is DeprecatorRole {
     event Deprecated(
-        bool seamless
+        bool rollover
     );
     event Undeprecated();
 
     uint256 public deprecatedBlock;
+    bool public rollover;
 
     constructor () internal {
         deprecatedBlock = 0;
-        seamless = False;
-
+        rollover = false;
     }
 
     /** Function only callable when not deprecated */
@@ -38,10 +38,10 @@ contract Deprecatable is DeprecatorRole {
      * Deprecate this contract
      * The contract disables new bounties, but allows other parts to function
      */
-    function deprecate(bool _seamless) external onlyDeprecator whenNotDeprecated {
+    function deprecate(bool _rollover) external onlyDeprecator whenNotDeprecated {
         deprecatedBlock = block.number;
-        seamless = _seamless;
-        emit Deprecated(seamless);
+        rollover = _rollover;
+        emit Deprecated(rollover);
     }
 
     /**
@@ -50,7 +50,7 @@ contract Deprecatable is DeprecatorRole {
      */
     function undeprecate() external onlyDeprecator whenDeprecated {
         deprecatedBlock = block.number;
-        seamless = false;
+        rollover = false;
         emit Undeprecated();
     }
 }

--- a/external/polyswarm/lifecycle/Deprecatable.sol
+++ b/external/polyswarm/lifecycle/Deprecatable.sol
@@ -45,7 +45,7 @@ contract Deprecatable is DeprecatorRole {
     }
 
     /**
-     * Undo deprecate om this contract
+     * Undo deprecate on this contract
      * The re-enables anything disabled by deprecation
      */
     function undeprecate() external onlyDeprecator whenDeprecated {

--- a/external/polyswarm/lifecycle/Deprecatable.sol
+++ b/external/polyswarm/lifecycle/Deprecatable.sol
@@ -18,6 +18,7 @@ contract Deprecatable is DeprecatorRole {
 
     constructor () internal {
         deprecatedBlock = 0;
+        seamless = False;
 
     }
 
@@ -27,21 +28,29 @@ contract Deprecatable is DeprecatorRole {
         _;
     }
 
+    /** Function only callable when deprecated */
+    modifier whenDeprecated() {
+        require(deprecatedBlock > 0);
+        _;
+    }
+
     /**
      * Deprecate this contract
      * The contract disables new bounties, but allows other parts to function
      */
-    function deprecate(bool seamless) external onlyDeprecator whenNotDeprecated {
+    function deprecate(bool _seamless) external onlyDeprecator whenNotDeprecated {
         deprecatedBlock = block.number;
+        seamless = _seamless;
         emit Deprecated(seamless);
     }
 
     /**
-     * Undeprecate this contract
+     * Undo deprecate om this contract
      * The re-enables anything disabled by deprecation
      */
-    function undeprecate() external onlyDeprecator whenNotDeprecated {
+    function undeprecate() external onlyDeprecator whenDeprecated {
         deprecatedBlock = block.number;
+        seamless = false;
         emit Undeprecated();
     }
 }

--- a/external/polyswarm/lifecycle/Deprecatable.sol
+++ b/external/polyswarm/lifecycle/Deprecatable.sol
@@ -9,12 +9,16 @@ import "../access/roles/DeprecatorRole.sol";
  * @dev Base contract which allows children to implement an emergency stop mechanism.
  */
 contract Deprecatable is DeprecatorRole {
-    event Deprecated();
+    event Deprecated(
+        bool seamless
+    );
+    event Undeprecated();
 
     uint256 public deprecatedBlock;
 
     constructor () internal {
         deprecatedBlock = 0;
+
     }
 
     /** Function only callable when not deprecated */
@@ -27,8 +31,17 @@ contract Deprecatable is DeprecatorRole {
      * Deprecate this contract
      * The contract disables new bounties, but allows other parts to function
      */
-    function deprecate() external onlyDeprecator whenNotDeprecated {
+    function deprecate(bool seamless) external onlyDeprecator whenNotDeprecated {
         deprecatedBlock = block.number;
-        emit Deprecated();
+        emit Deprecated(seamless);
+    }
+
+    /**
+     * Undeprecate this contract
+     * The re-enables anything disabled by deprecation
+     */
+    function undeprecate() external onlyDeprecator whenNotDeprecated {
+        deprecatedBlock = block.number;
+        emit Undeprecated();
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def parse_requirements():
 
 setup(
     name='contractor',
-    version='0.2.0',
+    version='0.3.0',
     description='Utilities for Ethereum smart contract development and deployment',
     author='PolySwarm Developers',
     author_email='info@polyswarm.io',

--- a/src/contractor/__main__.py
+++ b/src/contractor/__main__.py
@@ -353,8 +353,7 @@ def deactivate(ctx):
               help='Input file containing the deployed addresses of our artifacts')
 @click.option('-t', '--timeout', type=int, default=60,
               help='Time to wait for input file to exist')
-@click.argument('contract',
-                help="Contract name to deactivate")
+@click.argument('contract')
 @click.pass_context
 def contract(ctx, config, community, network, chain, keyfile, password, trezor, trezor_path, derivation_path,
               artifactdir, input, timeout, contract):
@@ -380,6 +379,7 @@ def contract(ctx, config, community, network, chain, keyfile, password, trezor, 
         deployer.load_results(f)
 
     steps.run(network, deployer, to_deploy=contract, deactivate=True)
+
 
 @deactivate.command()
 @click.option('--config', envvar='CONFIG', type=click.File('r'), required=True,

--- a/src/contractor/steps/ArbiterStaking.py
+++ b/src/contractor/steps/ArbiterStaking.py
@@ -1,5 +1,6 @@
 import logging
 
+from contractor.network import Chain
 from contractor.steps import Step
 
 logger = logging.getLogger(__name__)
@@ -25,5 +26,16 @@ class ArbiterStaking(Step):
 
         contract_config = network.contract_config.get(CONTRACT_NAME, {})
         stake_duration = contract_config.get('stake_duration', 100)
+
+        address = None
+        if network.chain == Chain.HOMECHAIN:
+            address = network.normalize_address(contract_config.get('home_address'))
+        elif network.chain == Chain.SIDECHAIN:
+            address = network.normalize_address(contract_config.get('side_address'))
+
+        if address and network.is_contract(address):
+            logger.warning('Using already deployed contract for network %s at %s', network.name, address)
+            deployer.at(CONTRACT_NAME, address)
+            return
 
         deployer.deploy(CONTRACT_NAME, nectar_token_address, stake_duration)

--- a/src/contractor/steps/BountyRegistry.py
+++ b/src/contractor/steps/BountyRegistry.py
@@ -54,10 +54,13 @@ class BountyRegistry(Step):
         :param deployer: Deployer for tearing down this contract and transacting resolving in progress tasks
         :return: None
         """
-        txhash = deployer.transact(deployer.contracts['BountyRegistry'].functions.deprecate())
+        contract_config = network.contract_config.get(CONTRACT_NAME, {})
+        # This is True when we don't want to trigger arbiter withdrawals
+        rollover = contract_config.get('rollover', False)
+        txhash = deployer.transact(deployer.contracts['BountyRegistry'].functions.deprecate(rollover))
+
         network.wait_and_check_transaction(txhash)
 
         revealWindow = deployer.contracts['BountyRegistry'].functions.assertionRevealWindow().call()
-        voteWindow = deployer.contracts['BountyRegistry'].functions.arbiterVoteWindow().call()
         max_duration = deployer.contracts['BountyRegistry'].functions.MAX_DURATION().call()
-        network.wait_for_blocks((revealWindow + voteWindow + max_duration) * 2)
+        network.wait_for_blocks((revealWindow + max_duration) * 2)

--- a/src/contractor/steps/ERC20Relay.py
+++ b/src/contractor/steps/ERC20Relay.py
@@ -79,6 +79,11 @@ class ERC20Relay(Step):
         :param deployer: deployer for deprecating and transacting resolving in progress tasks
         :return: None
         """
+        # Wait until the vote window closed (BountyRegistry already waited on others)
+        voteWindow = deployer.contracts['BountyRegistry'].functions.arbiterVoteWindow().call()
+        network.wait_for_blocks((voteWindow) * 2)
+
+        # Trigger flush
         txhash = deployer.transact(deployer.contracts['ERC20Relay'].functions.flush())
         network.wait_and_check_transaction(txhash)
 

--- a/src/contractor/steps/ERC20Relay.py
+++ b/src/contractor/steps/ERC20Relay.py
@@ -81,7 +81,7 @@ class ERC20Relay(Step):
         """
         # Wait until the vote window closed (BountyRegistry already waited on others)
         voteWindow = deployer.contracts['BountyRegistry'].functions.arbiterVoteWindow().call()
-        network.wait_for_blocks((voteWindow) * 2)
+        network.wait_for_blocks(int(voteWindow * 1.2))
 
         # Trigger flush
         txhash = deployer.transact(deployer.contracts['ERC20Relay'].functions.flush())

--- a/tests/test_ArbiterStaking.py
+++ b/tests/test_ArbiterStaking.py
@@ -181,7 +181,7 @@ def test_allow_withdrawals_after_deprecation(arbiter_long_staking, eth_tester):
     with pytest.raises(TransactionFailed):
         ArbiterStaking.functions.withdraw(1).transact({'from': ArbiterStaking.arbiter.address})
 
-    BountyRegistry.functions.deprecate().transact({'from': BountyRegistry.owner})
+    BountyRegistry.functions.deprecate(False).transact({'from': BountyRegistry.owner})
 
     eth_tester.mine_blocks(BountyRegistry.functions.MAX_DURATION().call())
     eth_tester.mine_blocks(BountyRegistry.functions.assertionRevealWindow().call())

--- a/tests/test_BountyRegistry.py
+++ b/tests/test_BountyRegistry.py
@@ -209,14 +209,33 @@ def test_should_allow_owner_to_perform_window_management_if_no_manager_set(bount
     BountyRegistry.functions.setWindows(3, 3).transact({'from': window_manager.address})
 
 
-def test_emit_event_deprecate(bounty_registry):
+def test_can_only_deprecate_when_not_deprecated(bounty_registry):
     BountyRegistry = bounty_registry.BountyRegistry
     network = bounty_registry.network
 
-    txhash = BountyRegistry.functions.deprecate(False).transact({"from": BountyRegistry.owner})
+    txhash = BountyRegistry.functions.deprecate(True).transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
 
+    with pytest.raises(TransactionFailed):
+        BountyRegistry.functions.deprecate(False).transact({"from": BountyRegistry.owner})
+
+    txhash = BountyRegistry.functions.undeprecate().transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Undeprecated())
+
+    txhash = BountyRegistry.functions.deprecate(True).transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+
+
+def test_deprecate_block_set(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    txhash = BountyRegistry.functions.deprecate(True).transact({"from": BountyRegistry.owner})
     deprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
-    assert deprecate is not None
+
+    deprecatedBlock = BountyRegistry.functions.deprecatedBlock().call()
+    rollover = BountyRegistry.functions.rollover().call()
+    assert deprecatedBlock > 0 and rollover
 
 
 def test_emit_event_deprecate_rollover(bounty_registry):
@@ -227,6 +246,56 @@ def test_emit_event_deprecate_rollover(bounty_registry):
 
     deprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
     assert deprecate is not None and deprecate[0]
+
+
+def test_emit_event_deprecate(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    txhash = BountyRegistry.functions.deprecate(False).transact({"from": BountyRegistry.owner})
+
+    deprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+    assert deprecate is not None
+
+
+def test_can_only_undeprecate_when_deprecated(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    with pytest.raises(TransactionFailed):
+        BountyRegistry.functions.undeprecate().transact({"from": BountyRegistry.owner})
+
+    txhash = BountyRegistry.functions.deprecate(True).transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+
+    txhash = BountyRegistry.functions.undeprecate().transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Undeprecated())
+
+
+def test_emit_event_undeprecate(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    txhash = BountyRegistry.functions.deprecate(False).transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+    txhash = BountyRegistry.functions.undeprecate().transact({"from": BountyRegistry.owner})
+
+    undeprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Undeprecated())
+    assert undeprecate is not None
+
+
+def test_undeprecate_resets_values(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    txhash = BountyRegistry.functions.deprecate(True).transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+    txhash = BountyRegistry.functions.undeprecate().transact({"from": BountyRegistry.owner})
+    network.wait_and_process_receipt(txhash, BountyRegistry.events.Undeprecated())
+
+    deprecatedBlock = BountyRegistry.functions.deprecatedBlock().call()
+    rollover = BountyRegistry.functions.rollover().call()
+    assert deprecatedBlock == 0 and not rollover
 
 
 def test_post_bounty(bounty_registry):

--- a/tests/test_BountyRegistry.py
+++ b/tests/test_BountyRegistry.py
@@ -213,10 +213,20 @@ def test_emit_event_deprecate(bounty_registry):
     BountyRegistry = bounty_registry.BountyRegistry
     network = bounty_registry.network
 
-    txhash = BountyRegistry.functions.deprecate().transact({"from": BountyRegistry.owner})
+    txhash = BountyRegistry.functions.deprecate(False).transact({"from": BountyRegistry.owner})
 
     deprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
     assert deprecate is not None
+
+
+def test_emit_event_deprecate_rollover(bounty_registry):
+    BountyRegistry = bounty_registry.BountyRegistry
+    network = bounty_registry.network
+
+    txhash = BountyRegistry.functions.deprecate(True).transact({"from": BountyRegistry.owner})
+
+    deprecate = network.wait_and_process_receipt(txhash, BountyRegistry.events.Deprecated())
+    assert deprecate is not None and deprecate[0]
 
 
 def test_post_bounty(bounty_registry):
@@ -280,7 +290,7 @@ def test_post_bounty_deprecated(bounty_registry):
     uri = random_artifact_uri()
     amount = 10 * 10 ** 18
 
-    BountyRegistry.functions.deprecate().transact({"from": BountyRegistry.owner})
+    BountyRegistry.functions.deprecate(False).transact({"from": BountyRegistry.owner})
 
     with pytest.raises(TransactionFailed):
         post_bounty(bounty_registry, ambassador.address, guid=guid, artifact_type=0, uri=uri, amount=amount)


### PR DESCRIPTION
Add a rollover field to `Deprecated` event so arbiters know whether or not to withdraw stake
Add `Undeprecated` event so failed upgrades can be rolled back

TODO
- [x] Add command to deprecate only `BountyRegistry`
- [x] Add configuration to skip `ArbiterStaking` redeploy & just rollover
- [x] PolySwarm Client support
- [x] PolySwarmd support